### PR TITLE
Use TimeSpanParser instead of ParseTimeSpan

### DIFF
--- a/src/Data/Options/TimeSpanOption.cs
+++ b/src/Data/Options/TimeSpanOption.cs
@@ -11,22 +11,17 @@ public sealed class TimeSpanOption : Option<TimeSpan>
     public override TimeSpan Get(JsonNode settings)
     {
         var property = settings[Name];
-        return property != null ? ParseTimeSpan(property.GetValue<string>()).Entity : DefaultValue;
+        return property != null ? TimeSpanParser.TryParse(property.GetValue<string>()).Entity : DefaultValue;
     }
 
     public override Result Set(JsonNode settings, string from)
     {
-        if (!ParseTimeSpan(from).IsDefined(out var span))
+        if (!TimeSpanParser.TryParse(from).IsDefined(out var span))
         {
             return new ArgumentInvalidError(nameof(from), Messages.InvalidSettingValue);
         }
 
         settings[Name] = span.ToString();
         return Result.FromSuccess();
-    }
-
-    private static Result<TimeSpan> ParseTimeSpan(string from)
-    {
-        return TimeSpanParser.TryParse(from);
     }
 }


### PR DESCRIPTION
The ParseTimeSpan method is not needed because we no longer use the quirky (IMO) and long `Parser.TryParseAsync(from).AsTask().GetAwaiter().GetResult()` to parse TimeSpan