### PR TITLE
Add time format example to the description of commands that use TimeSpan.

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -654,4 +654,7 @@
   <data name="EightBallNegative5" xml:space="preserve">
       <value>Very doubtful</value>
   </data>
+  <data name="TimeSpanExample" xml:space="preserve">
+      <value>Example of a valid input: `1h30m`</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -654,4 +654,7 @@
   <data name="EightBallNegative5" xml:space="preserve">
       <value>Весьма сомнительно</value>
   </data>
+  <data name="TimeSpanExample" xml:space="preserve">
+      <value>Пример правильного ввода: `1h30m`</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -655,6 +655,6 @@
       <value>Весьма сомнительно</value>
   </data>
   <data name="TimeSpanExample" xml:space="preserve">
-      <value>Пример правильного ввода: `1h30m`</value>
+      <value>Пример правильного ввода: `1ч30м`</value>
   </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -654,4 +654,7 @@
   <data name="EightBallNegative5" xml:space="preserve">
       <value>чот сомневаюсь</value>
   </data>
+  <data name="TimeSpanExample" xml:space="preserve">
+      <value>правильно пишут так: `1h30m`</value>
+  </data>
 </root>

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -76,7 +76,8 @@ public class BanCommandGroup : CommandGroup
         [Description("User to ban")] IUser target,
         [Description("Ban reason")] [MaxLength(256)]
         string reason,
-        [Description("Ban duration")] string? duration = null)
+        [Description("Ban duration (e.g. 1h30m)")]
+        string? duration = null)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
         {
@@ -116,6 +117,7 @@ public class BanCommandGroup : CommandGroup
         {
             var failedEmbed = new EmbedBuilder()
                 .WithSmallTitle(Messages.InvalidTimeSpan, bot)
+                .WithDescription(Messages.TimeSpanExample)
                 .WithColour(ColorsList.Red)
                 .Build();
 

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -73,7 +73,7 @@ public class MuteCommandGroup : CommandGroup
         [Description("Member to mute")] IUser target,
         [Description("Mute reason")] [MaxLength(256)]
         string reason,
-        [Description("Mute duration")] [Option("duration")]
+        [Description("Mute duration (e.g. 1h30m)")] [Option("duration")]
         string stringDuration)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
@@ -111,6 +111,7 @@ public class MuteCommandGroup : CommandGroup
         {
             var failedEmbed = new EmbedBuilder()
                 .WithSmallTitle(Messages.InvalidTimeSpan, bot)
+                .WithDescription(Messages.TimeSpanExample)
                 .WithColour(ColorsList.Red)
                 .Build();
 

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -120,7 +120,7 @@ public class RemindCommandGroup : CommandGroup
     [RequireContext(ChannelContext.Guild)]
     [UsedImplicitly]
     public async Task<Result> ExecuteReminderAsync(
-        [Description("After what period of time mention the reminder")]
+        [Description("After what period of time mention the reminder (e.g. 1h30m)")]
         [Option("in")]
         string timeSpanString,
         [Description("Reminder text")] [MaxLength(512)]

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -151,6 +151,7 @@ public class RemindCommandGroup : CommandGroup
         {
             var failedEmbed = new EmbedBuilder()
                 .WithSmallTitle(Messages.InvalidTimeSpan, bot)
+                .WithDescription(Messages.TimeSpanExample)
                 .WithColour(ColorsList.Red)
                 .Build();
 
@@ -264,6 +265,7 @@ public class RemindCommandGroup : CommandGroup
         {
             var failedEmbed = new EmbedBuilder()
                 .WithSmallTitle(Messages.InvalidTimeSpan, bot)
+                .WithDescription(Messages.TimeSpanExample)
                 .WithColour(ColorsList.Red)
                 .Build();
 

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -461,6 +461,7 @@ public class ToolsCommandGroup : CommandGroup
         {
             var failedEmbed = new EmbedBuilder()
                 .WithSmallTitle(Messages.InvalidTimeSpan, bot)
+                .WithDescription(Messages.TimeSpanExample)
                 .WithColour(ColorsList.Red)
                 .Build();
 

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -1178,5 +1178,11 @@ namespace Octobot {
                 return ResourceManager.GetString("EightBallNegative5", resourceCulture);
             }
         }
+
+        internal static string TimeSpanExample {
+            get {
+                return ResourceManager.GetString("TimeSpanExample", resourceCulture);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR was made to help users who are trying /remind for the first time by showing an example of the correct time format in the description to avoid this:

![](https://github.com/TeamOctolings/Octobot/assets/95250141/ab950c8c-afdd-4b01-acea-7ef4cf379754)
