### PR TITLE
Rename locale Sound to Loaded for clarity

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -117,13 +117,13 @@
   <data name="DefaultWelcomeMessage" xml:space="preserve">
     <value>{0}, welcome to {1}</value>
   </data>
-  <data name="Sound1" xml:space="preserve">
+  <data name="Loaded1" xml:space="preserve">
       <value>Veemo!</value>
   </data>
-  <data name="Sound2" xml:space="preserve">
+  <data name="Loaded2" xml:space="preserve">
       <value>Woomy!</value>
   </data>
-  <data name="Sound3" xml:space="preserve">
+  <data name="Loaded3" xml:space="preserve">
       <value>Ngyes!</value>
   </data>
   <data name="YouWereBanned" xml:space="preserve">

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -117,13 +117,13 @@
   <data name="DefaultWelcomeMessage" xml:space="preserve">
     <value>{0}, добро пожаловать на сервер {1}</value>
   </data>
-  <data name="Sound1" xml:space="preserve">
+  <data name="Loaded1" xml:space="preserve">
       <value>Виимо!</value>
   </data>
-  <data name="Sound2" xml:space="preserve">
+  <data name="Loaded2" xml:space="preserve">
       <value>Вууми!</value>
   </data>
-  <data name="Sound3" xml:space="preserve">
+  <data name="Loaded3" xml:space="preserve">
       <value>Нгьес!</value>
   </data>
   <data name="PunishmentExpired" xml:space="preserve">

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -117,13 +117,13 @@
   <data name="DefaultWelcomeMessage" xml:space="preserve">
     <value>{0}, добро пожаловать на сервер {1}</value>
   </data>
-  <data name="Sound1" xml:space="preserve">
+  <data name="Loaded1" xml:space="preserve">
       <value>вииимо!</value>
   </data>
-  <data name="Sound2" xml:space="preserve">
+  <data name="Loaded2" xml:space="preserve">
       <value>вуууми!</value>
   </data>
-  <data name="Sound3" xml:space="preserve">
+  <data name="Loaded3" xml:space="preserve">
       <value>нгьес!</value>
   </data>
   <data name="YouWereBanned" xml:space="preserve">

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -66,21 +66,21 @@ namespace Octobot {
             }
         }
 
-        internal static string Sound1 {
+        internal static string Loaded1 {
             get {
-                return ResourceManager.GetString("Sound1", resourceCulture);
+                return ResourceManager.GetString("Loaded1", resourceCulture);
             }
         }
 
-        internal static string Sound2 {
+        internal static string Loaded2 {
             get {
-                return ResourceManager.GetString("Sound2", resourceCulture);
+                return ResourceManager.GetString("Loaded2", resourceCulture);
             }
         }
 
-        internal static string Sound3 {
+        internal static string Loaded3 {
             get {
-                return ResourceManager.GetString("Sound3", resourceCulture);
+                return ResourceManager.GetString("Loaded3", resourceCulture);
             }
         }
 

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -88,7 +88,7 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
         var i = Random.Shared.Next(1, 4);
 
         var embed = new EmbedBuilder().WithSmallTitle(bot.GetTag(), bot)
-            .WithTitle($"Sound{i}".Localized())
+            .WithTitle($"Loaded{i}".Localized())
             .WithDescription(Messages.Ready)
             .WithCurrentTimestamp()
             .WithColour(ColorsList.Blue)


### PR DESCRIPTION
If you go through the locales, sooner or later you will notice `Sound*`, which is used in `GuildLoadedResponder.cs`. A new contributor (most likely) will not understand what it is used for at once, because we use `$"Loaded{i}".Localized()` instead of `Messages.Sound*` directly. Also, if you change the locale's value, for example the same "Loaded!", `Sound` will not fit anymore, because "Loaded!" is not a sound, but a phrase.

Other suggestions are welcome.