### PR TITLE
Disable issue report button if dirty version detected

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -664,6 +664,6 @@
       <value>Welcome messages channel</value>
   </data>
   <data name="ButtonDirty" xml:space="preserve">
-      <value>Can't report an issue in the under development version</value>
+      <value>Can't report an issue in the development version</value>
   </data>
 </root>

--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -664,6 +664,6 @@
       <value>Welcome messages channel</value>
   </data>
   <data name="ButtonDirty" xml:space="preserve">
-      <value>Can't report an issue in the dirty version</value>
+      <value>Can't report an issue in the under development version</value>
   </data>
 </root>

--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -663,4 +663,7 @@
   <data name="SettingsWelcomeMessagesChannel" xml:space="preserve">
       <value>Welcome messages channel</value>
   </data>
+  <data name="ButtonDirty" xml:space="preserve">
+      <value>Can't report an issue in the dirty version</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -664,6 +664,6 @@
       <value>Канал для приветствий</value>
   </data>
   <data name="ButtonDirty" xml:space="preserve">
-      <value>Нельзя сообщить о проблеме в dirty версии</value>
+      <value>Нельзя сообщить о проблеме в версии под разработкой</value>
   </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -663,4 +663,7 @@
   <data name="SettingsWelcomeMessagesChannel" xml:space="preserve">
       <value>Канал для приветствий</value>
   </data>
+  <data name="ButtonDirty" xml:space="preserve">
+      <value>Нельзя сообщить о проблеме в dirty версии</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -663,4 +663,7 @@
   <data name="SettingsWelcomeMessagesChannel" xml:space="preserve">
       <value>канал куда говорить здравствуйте</value>
   </data>
+  <data name="ButtonDirty" xml:space="preserve">
+      <value>вот иди сам и почини что сломал</value>
+  </data>
 </root>

--- a/src/BuildInfo.cs
+++ b/src/BuildInfo.cs
@@ -34,7 +34,7 @@ public static class BuildInfo
         }
     }
 
-    private static bool IsDirty
+    public static bool IsDirty
     {
         get
         {

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -111,6 +111,22 @@ public class AboutCommandGroup : CommandGroup
             URL: BuildInfo.RepositoryUrl
         );
 
+        if (BuildInfo.IsDirty)
+        {
+            var dirtyButton = new ButtonComponent(
+                ButtonComponentStyle.Link,
+                Messages.ButtonDirty,
+                new PartialEmoji(Name: "⚠️"),
+                IsDisabled: true
+            );
+
+            return await _feedback.SendContextualEmbedResultAsync(embed,
+                new FeedbackMessageOptions(MessageComponents: new[]
+                {
+                    new ActionRowComponent(new[] { repositoryButton, dirtyButton })
+                }), ct);
+        }
+
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonReportIssue,

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -117,6 +117,7 @@ public class AboutCommandGroup : CommandGroup
                 ButtonComponentStyle.Link,
                 Messages.ButtonDirty,
                 new PartialEmoji(Name: "⚠️"),
+                URL: BuildInfo.IssuesUrl,
                 IsDisabled: true
             );
 

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -111,28 +111,14 @@ public class AboutCommandGroup : CommandGroup
             URL: BuildInfo.RepositoryUrl
         );
 
-        if (BuildInfo.IsDirty)
-        {
-            var dirtyButton = new ButtonComponent(
-                ButtonComponentStyle.Link,
-                Messages.ButtonDirty,
-                new PartialEmoji(Name: "⚠️"),
-                URL: BuildInfo.IssuesUrl,
-                IsDisabled: true
-            );
-
-            return await _feedback.SendContextualEmbedResultAsync(embed,
-                new FeedbackMessageOptions(MessageComponents: new[]
-                {
-                    new ActionRowComponent(new[] { repositoryButton, dirtyButton })
-                }), ct);
-        }
-
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
-            Messages.ButtonReportIssue,
+            BuildInfo.IsDirty
+                ? Messages.ButtonReportIssue
+                : Messages.ButtonDirty,
             new PartialEmoji(Name: "⚠️"),
-            URL: BuildInfo.IssuesUrl
+            URL: BuildInfo.IssuesUrl,
+            IsDisabled: BuildInfo.IsDirty
         );
 
         return await _feedback.SendContextualEmbedResultAsync(embed,

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -114,8 +114,8 @@ public class AboutCommandGroup : CommandGroup
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             BuildInfo.IsDirty
-                ? Messages.ButtonReportIssue
-                : Messages.ButtonDirty,
+                ? Messages.ButtonDirty
+                : Messages.ButtonReportIssue,
             new PartialEmoji(Name: "⚠️"),
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -68,6 +68,22 @@ public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
             .WithColour(ColorsList.Red)
             .Build();
 
+        if (BuildInfo.IsDirty)
+        {
+            var dirtyButton = new ButtonComponent(
+                ButtonComponentStyle.Link,
+                Messages.ButtonDirty,
+                new PartialEmoji(Name: "⚠️"),
+                IsDisabled: true
+            );
+
+            return await _feedback.SendContextualEmbedResultAsync(embed,
+                new FeedbackMessageOptions(MessageComponents: new[]
+                {
+                    new ActionRowComponent(new[] { dirtyButton })
+                }), ct);
+        }
+
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonReportIssue,

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -74,6 +74,7 @@ public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
                 ButtonComponentStyle.Link,
                 Messages.ButtonDirty,
                 new PartialEmoji(Name: "⚠️"),
+                URL: BuildInfo.IssuesUrl,
                 IsDisabled: true
             );
 

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -71,8 +71,8 @@ public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             BuildInfo.IsDirty
-                ? Messages.ButtonReportIssue
-                : Messages.ButtonDirty,
+                ? Messages.ButtonDirty
+                : Messages.ButtonReportIssue,
             new PartialEmoji(Name: "⚠️"),
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -68,28 +68,14 @@ public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
             .WithColour(ColorsList.Red)
             .Build();
 
-        if (BuildInfo.IsDirty)
-        {
-            var dirtyButton = new ButtonComponent(
-                ButtonComponentStyle.Link,
-                Messages.ButtonDirty,
-                new PartialEmoji(Name: "⚠️"),
-                URL: BuildInfo.IssuesUrl,
-                IsDisabled: true
-            );
-
-            return await _feedback.SendContextualEmbedResultAsync(embed,
-                new FeedbackMessageOptions(MessageComponents: new[]
-                {
-                    new ActionRowComponent(new[] { dirtyButton })
-                }), ct);
-        }
-
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
-            Messages.ButtonReportIssue,
+            BuildInfo.IsDirty
+                ? Messages.ButtonReportIssue
+                : Messages.ButtonDirty,
             new PartialEmoji(Name: "⚠️"),
-            URL: BuildInfo.IssuesUrl
+            URL: BuildInfo.IssuesUrl,
+            IsDisabled: BuildInfo.IsDirty
         );
 
         return await _feedback.SendContextualEmbedResultAsync(embed,

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -1196,5 +1196,11 @@ namespace Octobot {
                 return ResourceManager.GetString("SettingsWelcomeMessagesChannel", resourceCulture);
             }
         }
+
+        internal static string ButtonDirty {
+            get {
+                return ResourceManager.GetString("ButtonDirty", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -113,6 +113,19 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
             .WithColour(ColorsList.Red)
             .Build();
 
+        if (BuildInfo.IsDirty)
+        {
+            var dirtyButton = new ButtonComponent(
+                ButtonComponentStyle.Link,
+                Messages.ButtonDirty,
+                new PartialEmoji(Name: "⚠️"),
+                IsDisabled: true
+            );
+
+            return await _channelApi.CreateMessageWithEmbedResultAsync(channel, embedResult: errorEmbed,
+                components: new[] { new ActionRowComponent(new[] { dirtyButton }) }, ct: ct);
+        }
+
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonReportIssue,

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -119,6 +119,7 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
                 ButtonComponentStyle.Link,
                 Messages.ButtonDirty,
                 new PartialEmoji(Name: "⚠️"),
+                URL: BuildInfo.IssuesUrl,
                 IsDisabled: true
             );
 

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -113,25 +113,14 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
             .WithColour(ColorsList.Red)
             .Build();
 
-        if (BuildInfo.IsDirty)
-        {
-            var dirtyButton = new ButtonComponent(
-                ButtonComponentStyle.Link,
-                Messages.ButtonDirty,
-                new PartialEmoji(Name: "⚠️"),
-                URL: BuildInfo.IssuesUrl,
-                IsDisabled: true
-            );
-
-            return await _channelApi.CreateMessageWithEmbedResultAsync(channel, embedResult: errorEmbed,
-                components: new[] { new ActionRowComponent(new[] { dirtyButton }) }, ct: ct);
-        }
-
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
-            Messages.ButtonReportIssue,
+            BuildInfo.IsDirty
+                ? Messages.ButtonReportIssue
+                : Messages.ButtonDirty,
             new PartialEmoji(Name: "⚠️"),
-            URL: BuildInfo.IssuesUrl
+            URL: BuildInfo.IssuesUrl,
+            IsDisabled: BuildInfo.IsDirty
         );
 
         return await _channelApi.CreateMessageWithEmbedResultAsync(channel, embedResult: errorEmbed,

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -116,8 +116,8 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
         var issuesButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             BuildInfo.IsDirty
-                ? Messages.ButtonReportIssue
-                : Messages.ButtonDirty,
+                ? Messages.ButtonDirty
+                : Messages.ButtonReportIssue,
             new PartialEmoji(Name: "⚠️"),
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty


### PR DESCRIPTION
In this PR, I'm disabling the Report Issue button if a "dirty" version is detected. This is done just in case so that "smart" developers don't accidentally report a bug that they themselves created.