### PR TITLE
Fix mctaylors-ru not working

### DIFF
--- a/src/Data/Options/LanguageOption.cs
+++ b/src/Data/Options/LanguageOption.cs
@@ -12,7 +12,7 @@ public sealed class LanguageOption : Option<CultureInfo>
     {
         { "en", new CultureInfo("en-US") },
         { "ru", new CultureInfo("ru-RU") },
-        { "mctaylors-ru", new CultureInfo("tt-RU") }
+        { "mctaylors", new CultureInfo("tt-RU") }
     };
 
     public LanguageOption(string name, string defaultValue) : base(name, CultureInfoCache[defaultValue]) { }


### PR DESCRIPTION
In fact, this problem has existed for a large amount of time, but I only took it up now. Renaming the locale name helped. Somehow. Don't ask me how. I don't know.

And also `mctaylors-ru` language users will have to change the language to `mctaylors` in the ~bot settings.~ `Settings.json`. Complex, but it's the only way out.

Closes #277 