### PR TITLE
Change position of "Jump to ..." action for better consistency

### DIFF
--- a/src/Responders/MessageDeletedResponder.cs
+++ b/src/Responders/MessageDeletedResponder.cs
@@ -83,10 +83,11 @@ public class MessageDeletedResponder : IResponder<IMessageDelete>
 
         Messages.Culture = GuildSettings.Language.Get(cfg);
 
-        var builder = new StringBuilder().AppendLine(
-                string.Format(Messages.DescriptionActionJumpToChannel,
-                    Mention.Channel(gatewayEvent.ChannelID)))
-            .AppendLine(message.Content.InBlockCode());
+        var builder = new StringBuilder()
+            .AppendLine(message.Content.InBlockCode())
+            .AppendLine(
+                string.Format(Messages.DescriptionActionJumpToChannel, Mention.Channel(gatewayEvent.ChannelID))
+            );
 
         var embed = new EmbedBuilder()
             .WithSmallTitle(

--- a/src/Responders/MessageEditedResponder.cs
+++ b/src/Responders/MessageEditedResponder.cs
@@ -101,10 +101,11 @@ public class MessageEditedResponder : IResponder<IMessageUpdate>
 
         Messages.Culture = GuildSettings.Language.Get(cfg);
 
-        var builder = new StringBuilder().AppendLine(
-                string.Format(Messages.DescriptionActionJumpToMessage,
-                    $"https://discord.com/channels/{guildId}/{channelId}/{messageId}"))
-            .AppendLine(diff.AsMarkdown());
+        var builder = new StringBuilder()
+            .AppendLine(diff.AsMarkdown())
+            .AppendLine(string.Format(Messages.DescriptionActionJumpToMessage,
+                $"https://discord.com/channels/{guildId}/{channelId}/{messageId}")
+            );
 
         var embed = new EmbedBuilder()
             .WithSmallTitle(string.Format(Messages.CachedMessageEdited, message.Author.GetTag()), message.Author)


### PR DESCRIPTION
This will better align with how a normal moderator would respond to the log:

Before: "see log" -> "jump to message without knowing what changed" -> "read message diff"
After: "see log" -> "read message diff" -> "jump to message for context"

In addition, the change improves consistency with how reminders are shown.