### PR TITLE
fix: do not use RepositoryUrl from GitInfo

### DIFF
--- a/src/BuildInfo.cs
+++ b/src/BuildInfo.cs
@@ -2,7 +2,7 @@
 
 public static class BuildInfo
 {
-    public static string RepositoryUrl => ThisAssembly.Git.RepositoryUrl;
+    public static string RepositoryUrl => "https://github.com/TeamOctolings/Octobot";
 
     public static string IssuesUrl => $"{RepositoryUrl}/issues";
 

--- a/src/BuildInfo.cs
+++ b/src/BuildInfo.cs
@@ -2,15 +2,15 @@
 
 public static class BuildInfo
 {
-    public static string RepositoryUrl => "https://github.com/TeamOctolings/Octobot";
+    public const string RepositoryUrl = "https://github.com/TeamOctolings/Octobot";
 
-    public static string IssuesUrl => $"{RepositoryUrl}/issues";
+    public const string IssuesUrl = $"{RepositoryUrl}/issues";
 
-    public static string WikiUrl => $"{RepositoryUrl}/wiki";
+    public const string WikiUrl = $"{RepositoryUrl}/wiki";
 
-    private static string Commit => ThisAssembly.Git.Commit;
+    private const string Commit = ThisAssembly.Git.Commit;
 
-    private static string Branch => ThisAssembly.Git.Branch;
+    private const string Branch = ThisAssembly.Git.Branch;
 
     public static bool IsDirty => ThisAssembly.Git.IsDirty;
 


### PR DESCRIPTION
GitInfo's `RepositoryUrl` string depends on origin URL, which is unvalidated user input that isn't even guaranteed to exist. This can cause [issues that are almost impossible to debug](https://github.com/TeamOctolings/Octobot/issues/281)

Closes #281 