### PR TITLE
Do not use ResultError#IsUserOrEnvironmentError

### DIFF
--- a/src/Extensions/LoggerExtensions.cs
+++ b/src/Extensions/LoggerExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Remora.Discord.Commands.Extensions;
 using Remora.Results;
 
 namespace Octobot.Extensions;
@@ -19,7 +18,7 @@ public static class LoggerExtensions
     /// <param name="message">The message to use if this result has failed.</param>
     public static void LogResult(this ILogger logger, IResult result, string? message = "")
     {
-        if (result.IsSuccess || result.Error.IsUserOrEnvironmentError())
+        if (result.IsSuccess)
         {
             return;
         }


### PR DESCRIPTION
In LoggerExtensions#LogResult we skip logging the result if the error is "user or environment error". What matches that criteria is defined by Remora's implementation:
```csharp
    public static bool IsUserOrEnvironmentError(this IResultError error)
    {
        return error
            is CommandNotFoundError
            or AmbiguousCommandInvocationError
            or RequiredParameterValueMissingError
            or ParameterParsingError
            or ConditionNotSatisfiedError;
    }
```
However, none of these errors should *ever* happen or be ignored:
* CommandNotFoundError: The client shouldn't send us non-existing commands. This *can* happen because the client's command list can get out of sync with the server's, but this happens rarely.
* AmbiguousCommandInvocationError: We don't have commands that would trigger this error
* RequiredParameterValueMissingError: The client shouldn't send us commands without required paremeters
* ParameterParsingError: See #220
* ConditionNotSatisfiedError: The client shouldn't send us commands that don't satisfy our conditions

Closes #220 