### PR TITLE
Use unicode codes instead of emojis

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -107,14 +107,14 @@ public class AboutCommandGroup : CommandGroup
         var repositoryButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonOpenRepository,
-            new PartialEmoji(Name: "🌐"),
+            new PartialEmoji(Name: "\ud83c\udf10"),
             URL: BuildInfo.RepositoryUrl
         );
 
         var wikiButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonOpenWiki,
-            new PartialEmoji(Name: "📖"),
+            new PartialEmoji(Name: "\ud83d\udcd6"),
             URL: BuildInfo.WikiUrl
         );
 
@@ -123,7 +123,7 @@ public class AboutCommandGroup : CommandGroup
             BuildInfo.IsDirty
                 ? Messages.ButtonDirty
                 : Messages.ButtonReportIssue,
-            new PartialEmoji(Name: "⚠️"),
+            new PartialEmoji(Name: "\u26a0\ufe0f"),
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty
         );

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -107,14 +107,14 @@ public class AboutCommandGroup : CommandGroup
         var repositoryButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonOpenRepository,
-            new PartialEmoji(Name: "\ud83c\udf10"),
+            new PartialEmoji(Name: "\ud83c\udf10"), // 'GLOBE WITH MERIDIANS' (U+1F310)
             URL: BuildInfo.RepositoryUrl
         );
 
         var wikiButton = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonOpenWiki,
-            new PartialEmoji(Name: "\ud83d\udcd6"),
+            new PartialEmoji(Name: "\ud83d\udcd6"), // 'OPEN BOOK' (U+1F4D6)
             URL: BuildInfo.WikiUrl
         );
 
@@ -123,7 +123,7 @@ public class AboutCommandGroup : CommandGroup
             BuildInfo.IsDirty
                 ? Messages.ButtonDirty
                 : Messages.ButtonReportIssue,
-            new PartialEmoji(Name: "\u26a0\ufe0f"),
+            new PartialEmoji(Name: "\u26a0\ufe0f"), // 'WARNING SIGN' (U+26A0)
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty
         );

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -73,7 +73,7 @@ public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
             BuildInfo.IsDirty
                 ? Messages.ButtonDirty
                 : Messages.ButtonReportIssue,
-            new PartialEmoji(Name: "⚠️"),
+            new PartialEmoji(Name: "\u26a0\ufe0f"),
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty
         );

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -73,7 +73,7 @@ public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
             BuildInfo.IsDirty
                 ? Messages.ButtonDirty
                 : Messages.ButtonReportIssue,
-            new PartialEmoji(Name: "\u26a0\ufe0f"),
+            new PartialEmoji(Name: "\u26a0\ufe0f"), // 'WARNING SIGN' (U+26A0)
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty
         );

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -114,7 +114,7 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
             BuildInfo.IsDirty
                 ? Messages.ButtonDirty
                 : Messages.ButtonReportIssue,
-            new PartialEmoji(Name: "\u26a0\ufe0f"),
+            new PartialEmoji(Name: "\u26a0\ufe0f"), // 'WARNING SIGN' (U+26A0)
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty
         );

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -114,7 +114,7 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
             BuildInfo.IsDirty
                 ? Messages.ButtonDirty
                 : Messages.ButtonReportIssue,
-            new PartialEmoji(Name: "⚠️"),
+            new PartialEmoji(Name: "\u26a0\ufe0f"),
             URL: BuildInfo.IssuesUrl,
             IsDisabled: BuildInfo.IsDirty
         );

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -223,7 +223,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         var button = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonOpenEventInfo,
-            new PartialEmoji(Name: "📋"),
+            new PartialEmoji(Name: "\ud83d\udccb"),
             URL: $"https://discord.com/events/{scheduledEvent.GuildID}/{scheduledEvent.ID}"
         );
 

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -223,7 +223,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         var button = new ButtonComponent(
             ButtonComponentStyle.Link,
             Messages.ButtonOpenEventInfo,
-            new PartialEmoji(Name: "\ud83d\udccb"),
+            new PartialEmoji(Name: "\ud83d\udccb"), // 'CLIPBOARD' (U+1F4CB)
             URL: $"https://discord.com/events/{scheduledEvent.GuildID}/{scheduledEvent.ID}"
         );
 


### PR DESCRIPTION
This change was made to avoid using emoji in the code, which may not render correctly depending on the IDE and/or operating system.