### PR TITLE
Make the logo in /about independent of image hosting

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -100,7 +100,7 @@ public class AboutCommandGroup : CommandGroup
             .WithSmallTitle(string.Format(Messages.AboutBot, bot.Username), bot)
             .WithDescription(builder.ToString())
             .WithColour(ColorsList.Cyan)
-            .WithImageUrl("https://i.ibb.co/fS6wZhh/octobot-banner.png")
+            .WithImageUrl("https://github.com/TeamOctolings/Octobot/raw/master/docs/octobot-banner.png")
             .WithFooter(string.Format(Messages.Version, BuildInfo.Version))
             .Build();
 

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -100,7 +100,7 @@ public class AboutCommandGroup : CommandGroup
             .WithSmallTitle(string.Format(Messages.AboutBot, bot.Username), bot)
             .WithDescription(builder.ToString())
             .WithColour(ColorsList.Cyan)
-            .WithImageUrl("https://github.com/TeamOctolings/Octobot/raw/master/docs/octobot-banner.png")
+            .WithImageUrl("https://raw.githubusercontent.com/TeamOctolings/Octobot/master/docs/octobot-banner.png")
             .WithFooter(string.Format(Messages.Version, BuildInfo.Version))
             .Build();
 


### PR DESCRIPTION
PR's name speaks for itself. It might also be useful to update the logo more easily.