### PR TITLE
Don't hardcode logo's link in /about

### DIFF
--- a/src/BuildInfo.cs
+++ b/src/BuildInfo.cs
@@ -10,7 +10,7 @@ public static class BuildInfo
 
     private const string Commit = ThisAssembly.Git.Commit;
 
-    private const string Branch = ThisAssembly.Git.Branch;
+    public const string Branch = ThisAssembly.Git.Branch;
 
     public static bool IsDirty => ThisAssembly.Git.IsDirty;
 

--- a/src/BuildInfo.cs
+++ b/src/BuildInfo.cs
@@ -10,7 +10,7 @@ public static class BuildInfo
 
     private const string Commit = ThisAssembly.Git.Commit;
 
-    public const string Branch = ThisAssembly.Git.Branch;
+    private const string Branch = ThisAssembly.Git.Branch;
 
     public static bool IsDirty => ThisAssembly.Git.IsDirty;
 

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -100,7 +100,7 @@ public class AboutCommandGroup : CommandGroup
             .WithSmallTitle(string.Format(Messages.AboutBot, bot.Username), bot)
             .WithDescription(builder.ToString())
             .WithColour(ColorsList.Cyan)
-            .WithImageUrl("https://raw.githubusercontent.com/TeamOctolings/Octobot/master/docs/octobot-banner.png")
+            .WithImageUrl($"https://raw.githubusercontent.com/TeamOctolings/Octobot/{BuildInfo.Branch}/docs/octobot-banner.png")
             .WithFooter(string.Format(Messages.Version, BuildInfo.Version))
             .Build();
 

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -100,7 +100,7 @@ public class AboutCommandGroup : CommandGroup
             .WithSmallTitle(string.Format(Messages.AboutBot, bot.Username), bot)
             .WithDescription(builder.ToString())
             .WithColour(ColorsList.Cyan)
-            .WithImageUrl($"https://raw.githubusercontent.com/TeamOctolings/Octobot/{BuildInfo.Branch}/docs/octobot-banner.png")
+            .WithImageUrl("https://raw.githubusercontent.com/TeamOctolings/Octobot/HEAD/docs/octobot-banner.png")
             .WithFooter(string.Format(Messages.Version, BuildInfo.Version))
             .Build();
 


### PR DESCRIPTION
In this PR, I made the logo link in /about use HEAD instead of hardcoded branch.