### PR TITLE
Enable result stacktraces in release mode

### DIFF
--- a/src/Extensions/ResultExtensions.cs
+++ b/src/Extensions/ResultExtensions.cs
@@ -21,7 +21,6 @@ public static class ResultExtensions
         return casted;
     }
 
-    [Conditional("DEBUG")]
     private static void LogResultStackTrace(Result result)
     {
         if (Octobot.StaticLogger is null || result.IsSuccess)


### PR DESCRIPTION
Originally I did not enable because "stack traces are expensive to retrieve", but let's be honest, who cares, this is a Discord bot, there's no such thing as "good performance"