### PR TITLE
Change assembly name back to "Octobot"

### DIFF
--- a/TeamOctolings.Octobot/TeamOctolings.Octobot.csproj
+++ b/TeamOctolings.Octobot/TeamOctolings.Octobot.csproj
@@ -18,6 +18,7 @@
         <Description>A general-purpose Discord bot for moderation written in C#</Description>
         <ApplicationIcon>../docs/octobot.ico</ApplicationIcon>
         <GitVersion>false</GitVersion>
+        <AssemblyName>Octobot</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Changing the project name ended up changing the names of the assemblies, which is a significant breaking change which caused our CD to fail