### PR TITLE
Seal implicitly used classes

### DIFF
--- a/TeamOctolings.Octobot/Commands/AboutCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/AboutCommandGroup.cs
@@ -25,7 +25,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles the command to show information about this bot: /about.
 /// </summary>
 [UsedImplicitly]
-public class AboutCommandGroup : CommandGroup
+public sealed class AboutCommandGroup : CommandGroup
 {
     private static readonly (string Username, Snowflake Id)[] Developers =
     [
@@ -36,9 +36,9 @@ public class AboutCommandGroup : CommandGroup
 
     private readonly ICommandContext _context;
     private readonly IFeedbackService _feedback;
+    private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
-    private readonly IDiscordRestGuildAPI _guildApi;
 
     public AboutCommandGroup(
         ICommandContext context, GuildDataService guildData,

--- a/TeamOctolings.Octobot/Commands/BanCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/BanCommandGroup.cs
@@ -26,7 +26,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles commands related to ban management: /ban and /unban.
 /// </summary>
 [UsedImplicitly]
-public class BanCommandGroup : CommandGroup
+public sealed class BanCommandGroup : CommandGroup
 {
     private readonly AccessControlService _access;
     private readonly IDiscordRestChannelAPI _channelApi;

--- a/TeamOctolings.Octobot/Commands/ClearCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/ClearCommandGroup.cs
@@ -23,7 +23,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles the command to clear messages in a channel: /clear.
 /// </summary>
 [UsedImplicitly]
-public class ClearCommandGroup : CommandGroup
+public sealed class ClearCommandGroup : CommandGroup
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly ICommandContext _context;

--- a/TeamOctolings.Octobot/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/TeamOctolings.Octobot/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -18,7 +18,7 @@ namespace TeamOctolings.Octobot.Commands.Events;
 ///     Handles error logging for slash command groups.
 /// </summary>
 [UsedImplicitly]
-public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
+public sealed class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
 {
     private readonly IFeedbackService _feedback;
     private readonly ILogger<ErrorLoggingPostExecutionEvent> _logger;

--- a/TeamOctolings.Octobot/Commands/Events/LoggingPreparationErrorEvent.cs
+++ b/TeamOctolings.Octobot/Commands/Events/LoggingPreparationErrorEvent.cs
@@ -11,7 +11,7 @@ namespace TeamOctolings.Octobot.Commands.Events;
 ///     Handles error logging for slash commands that couldn't be successfully prepared.
 /// </summary>
 [UsedImplicitly]
-public class LoggingPreparationErrorEvent : IPreparationErrorEvent
+public sealed class LoggingPreparationErrorEvent : IPreparationErrorEvent
 {
     private readonly ILogger<LoggingPreparationErrorEvent> _logger;
 

--- a/TeamOctolings.Octobot/Commands/InfoCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/InfoCommandGroup.cs
@@ -23,7 +23,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles info commands: /userinfo, /guildinfo.
 /// </summary>
 [UsedImplicitly]
-public class InfoCommandGroup : CommandGroup
+public sealed class InfoCommandGroup : CommandGroup
 {
     private readonly ICommandContext _context;
     private readonly IFeedbackService _feedback;

--- a/TeamOctolings.Octobot/Commands/KickCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/KickCommandGroup.cs
@@ -22,7 +22,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles the command to kick members of a guild: /kick.
 /// </summary>
 [UsedImplicitly]
-public class KickCommandGroup : CommandGroup
+public sealed class KickCommandGroup : CommandGroup
 {
     private readonly AccessControlService _access;
     private readonly IDiscordRestChannelAPI _channelApi;

--- a/TeamOctolings.Octobot/Commands/MuteCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/MuteCommandGroup.cs
@@ -26,7 +26,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles commands related to mute management: /mute and /unmute.
 /// </summary>
 [UsedImplicitly]
-public class MuteCommandGroup : CommandGroup
+public sealed class MuteCommandGroup : CommandGroup
 {
     private readonly AccessControlService _access;
     private readonly ICommandContext _context;

--- a/TeamOctolings.Octobot/Commands/PingCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/PingCommandGroup.cs
@@ -22,7 +22,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles the command to get the time taken for the gateway to respond to the last heartbeat: /ping
 /// </summary>
 [UsedImplicitly]
-public class PingCommandGroup : CommandGroup
+public sealed class PingCommandGroup : CommandGroup
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly DiscordGatewayClient _client;

--- a/TeamOctolings.Octobot/Commands/RemindCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/RemindCommandGroup.cs
@@ -25,13 +25,13 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles commands to manage reminders: /remind, /listremind, /delremind
 /// </summary>
 [UsedImplicitly]
-public class RemindCommandGroup : CommandGroup
+public sealed class RemindCommandGroup : CommandGroup
 {
     private readonly IInteractionCommandContext _context;
     private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
-    private readonly IDiscordRestUserAPI _userApi;
     private readonly IDiscordRestInteractionAPI _interactionApi;
+    private readonly IDiscordRestUserAPI _userApi;
 
     public RemindCommandGroup(
         IInteractionCommandContext context, GuildDataService guildData, IFeedbackService feedback,

--- a/TeamOctolings.Octobot/Commands/SettingsCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/SettingsCommandGroup.cs
@@ -26,7 +26,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles the commands to list and modify per-guild settings: /settings and /settings list.
 /// </summary>
 [UsedImplicitly]
-public class SettingsCommandGroup : CommandGroup
+public sealed class SettingsCommandGroup : CommandGroup
 {
     /// <summary>
     ///     Represents all options as an array of objects implementing <see cref="IGuildOption" />.

--- a/TeamOctolings.Octobot/Commands/ToolsCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/ToolsCommandGroup.cs
@@ -22,7 +22,7 @@ namespace TeamOctolings.Octobot.Commands;
 ///     Handles tool commands: /random, /timestamp, /8ball.
 /// </summary>
 [UsedImplicitly]
-public class ToolsCommandGroup : CommandGroup
+public sealed class ToolsCommandGroup : CommandGroup
 {
     private static readonly TimestampStyle[] AllStyles =
     [

--- a/TeamOctolings.Octobot/Responders/GuildLoadedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/GuildLoadedResponder.cs
@@ -19,7 +19,7 @@ namespace TeamOctolings.Octobot.Responders;
 ///     has <see cref="GuildSettings.ReceiveStartupMessages" /> enabled
 /// </summary>
 [UsedImplicitly]
-public class GuildLoadedResponder : IResponder<IGuildCreate>
+public sealed class GuildLoadedResponder : IResponder<IGuildCreate>
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly GuildDataService _guildData;

--- a/TeamOctolings.Octobot/Responders/GuildMemberJoinedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/GuildMemberJoinedResponder.cs
@@ -18,7 +18,7 @@ namespace TeamOctolings.Octobot.Responders;
 /// </summary>
 /// <seealso cref="GuildSettings.WelcomeMessage" />
 [UsedImplicitly]
-public class GuildMemberJoinedResponder : IResponder<IGuildMemberAdd>
+public sealed class GuildMemberJoinedResponder : IResponder<IGuildMemberAdd>
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly IDiscordRestGuildAPI _guildApi;

--- a/TeamOctolings.Octobot/Responders/GuildMemberLeftResponder.cs
+++ b/TeamOctolings.Octobot/Responders/GuildMemberLeftResponder.cs
@@ -15,7 +15,7 @@ namespace TeamOctolings.Octobot.Responders;
 /// </summary>
 /// <seealso cref="GuildSettings.LeaveMessage" />
 [UsedImplicitly]
-public class GuildMemberLeftResponder : IResponder<IGuildMemberRemove>
+public sealed class GuildMemberLeftResponder : IResponder<IGuildMemberRemove>
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly IDiscordRestGuildAPI _guildApi;

--- a/TeamOctolings.Octobot/Responders/GuildUnloadedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/GuildUnloadedResponder.cs
@@ -12,7 +12,7 @@ namespace TeamOctolings.Octobot.Responders;
 ///     Handles removing guild ID from <see cref="GuildData" /> if the guild becomes unavailable.
 /// </summary>
 [UsedImplicitly]
-public class GuildUnloadedResponder : IResponder<IGuildDelete>
+public sealed class GuildUnloadedResponder : IResponder<IGuildDelete>
 {
     private readonly GuildDataService _guildData;
     private readonly ILogger<GuildUnloadedResponder> _logger;

--- a/TeamOctolings.Octobot/Responders/MessageDeletedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/MessageDeletedResponder.cs
@@ -18,7 +18,7 @@ namespace TeamOctolings.Octobot.Responders;
 ///     to a guild's <see cref="GuildSettings.PrivateFeedbackChannel" /> if one is set.
 /// </summary>
 [UsedImplicitly]
-public class MessageDeletedResponder : IResponder<IMessageDelete>
+public sealed class MessageDeletedResponder : IResponder<IMessageDelete>
 {
     private readonly IDiscordRestAuditLogAPI _auditLogApi;
     private readonly IDiscordRestChannelAPI _channelApi;

--- a/TeamOctolings.Octobot/Responders/MessageEditedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/MessageEditedResponder.cs
@@ -20,7 +20,7 @@ namespace TeamOctolings.Octobot.Responders;
 ///     to a guild's <see cref="GuildSettings.PrivateFeedbackChannel" /> if one is set.
 /// </summary>
 [UsedImplicitly]
-public class MessageEditedResponder : IResponder<IMessageUpdate>
+public sealed class MessageEditedResponder : IResponder<IMessageUpdate>
 {
     private readonly CacheService _cacheService;
     private readonly IDiscordRestChannelAPI _channelApi;

--- a/TeamOctolings.Octobot/Responders/MessageReceivedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/MessageReceivedResponder.cs
@@ -11,7 +11,7 @@ namespace TeamOctolings.Octobot.Responders;
 ///     Handles sending replies to easter egg messages.
 /// </summary>
 [UsedImplicitly]
-public class MessageCreateResponder : IResponder<IMessageCreate>
+public sealed class MessageCreateResponder : IResponder<IMessageCreate>
 {
     private readonly IDiscordRestChannelAPI _channelApi;
 


### PR DESCRIPTION
Apparently the `[UsedImplicitly]` annotation suppresses the "Class has no inheritors and can be marked sealed" warning. Cool to know.