### PR TITLE
Use MemberData roles when checking permissions & interactions

### DIFF
--- a/TeamOctolings.Octobot/Services/AccessControlService.cs
+++ b/TeamOctolings.Octobot/Services/AccessControlService.cs
@@ -113,6 +113,11 @@ public sealed class AccessControlService
         string action, IGuild guild, IReadOnlyList<IRole> roles, MemberData targetData, MemberData botData,
         MemberData interacterData)
     {
+        if (botData.Id == targetData.Id)
+        {
+            return Result<string?>.FromSuccess($"UserCannot{action}Bot".Localized());
+        }
+
         if (targetData.Id == guild.OwnerID)
         {
             return Result<string?>.FromSuccess($"UserCannot{action}Owner".Localized());


### PR DESCRIPTION
Closes #311 

This change fixes unexpected behavior when a member's Discord roles get desynchronized with their MemberData roles (e.g. when a member gets role-muted). In addition this results in less API requests being made when there are cache misses (commands should execute faster)