### PR TITLE
Handle audit log entries for message deletion being empty

### DIFF
--- a/TeamOctolings.Octobot/Responders/MessageDeletedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/MessageDeletedResponder.cs
@@ -66,10 +66,10 @@ public sealed class MessageDeletedResponder : IResponder<IMessageDelete>
             return ResultExtensions.FromError(auditLogResult);
         }
 
-        var auditLog = auditLogPage.AuditLogEntries.Single();
-
         var deleterResult = Result<IUser>.FromSuccess(message.Author);
-        if (auditLog.UserID is not null
+
+        var auditLog = auditLogPage.AuditLogEntries.SingleOrDefault();
+        if (auditLog is { UserID: not null }
             && auditLog.Options.Value.ChannelID == gatewayEvent.ChannelID
             && DateTimeOffset.UtcNow.Subtract(auditLog.ID.Timestamp).TotalSeconds <= 2)
         {


### PR DESCRIPTION
In order to determine who deleted a message, Octobot fetches the audit log with a filter on the action "Message Delete", gets the latest entry and uses its author if the timestamps roughly match. However, if the filter returns no entries (as in, no message deletions are present in the audit log), `Single()` will throw an exception with the message `Sequence contains no elements`. To fix this, this PR replaces `Single()` with `SingleOrDefault()` and adds a null-check on `auditLog` in the form of a pattern access