### PR TITLE
Always default cancellation tokens

### DIFF
--- a/TeamOctolings.Octobot/Commands/InfoCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/InfoCommandGroup.cs
@@ -288,7 +288,7 @@ public sealed class InfoCommandGroup : CommandGroup
         return await ShowGuildInfoAsync(bot, guild, CancellationToken);
     }
 
-    private Task<Result> ShowGuildInfoAsync(IUser bot, IGuild guild, CancellationToken ct)
+    private Task<Result> ShowGuildInfoAsync(IUser bot, IGuild guild, CancellationToken ct = default)
     {
         var description = new StringBuilder().AppendLine($"## {guild.Name}");
 

--- a/TeamOctolings.Octobot/Commands/MuteCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/MuteCommandGroup.cs
@@ -170,7 +170,7 @@ public sealed class MuteCommandGroup : CommandGroup
 
     private async Task<Result> SelectMuteMethodAsync(
         IUser executor, IUser target, string reason, TimeSpan duration, Snowflake guildId, GuildData data,
-        IUser bot, DateTimeOffset until, CancellationToken ct)
+        IUser bot, DateTimeOffset until, CancellationToken ct = default)
     {
         var muteRole = GuildSettings.MuteRole.Get(data.Settings);
 
@@ -186,7 +186,7 @@ public sealed class MuteCommandGroup : CommandGroup
 
     private async Task<Result> RoleMuteUserAsync(
         IUser executor, IUser target, string reason, Snowflake guildId, GuildData data,
-        DateTimeOffset until, Snowflake muteRole, CancellationToken ct)
+        DateTimeOffset until, Snowflake muteRole, CancellationToken ct = default)
     {
         var assignRoles = new List<Snowflake> { muteRole };
         var memberData = data.GetOrCreateMemberData(target.ID);
@@ -208,7 +208,7 @@ public sealed class MuteCommandGroup : CommandGroup
 
     private async Task<Result> TimeoutUserAsync(
         IUser executor, IUser target, string reason, TimeSpan duration, Snowflake guildId,
-        IUser bot, DateTimeOffset until, CancellationToken ct)
+        IUser bot, DateTimeOffset until, CancellationToken ct = default)
     {
         if (duration.TotalDays >= 28)
         {

--- a/TeamOctolings.Octobot/Commands/RemindCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/RemindCommandGroup.cs
@@ -78,7 +78,7 @@ public sealed class RemindCommandGroup : CommandGroup
         return await ListRemindersAsync(data.GetOrCreateMemberData(executorId), guildId, executor, bot, CancellationToken);
     }
 
-    private Task<Result> ListRemindersAsync(MemberData data, Snowflake guildId, IUser executor, IUser bot, CancellationToken ct)
+    private Task<Result> ListRemindersAsync(MemberData data, Snowflake guildId, IUser executor, IUser bot, CancellationToken ct = default)
     {
         if (data.Reminders.Count == 0)
         {
@@ -353,7 +353,7 @@ public sealed class RemindCommandGroup : CommandGroup
     }
 
     private Task<Result> DeleteReminderAsync(MemberData data, int index, IUser bot,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
         if (index >= data.Reminders.Count)
         {

--- a/TeamOctolings.Octobot/Commands/ToolsCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/ToolsCommandGroup.cs
@@ -90,7 +90,7 @@ public sealed class ToolsCommandGroup : CommandGroup
     }
 
     private Task<Result> SendRandomNumberAsync(long first, long? secondNullable,
-        IUser executor, CancellationToken ct)
+        IUser executor, CancellationToken ct = default)
     {
         const long secondDefault = 0;
         var second = secondNullable ?? secondDefault;
@@ -187,7 +187,7 @@ public sealed class ToolsCommandGroup : CommandGroup
         return await SendTimestampAsync(offset, executor, CancellationToken);
     }
 
-    private Task<Result> SendTimestampAsync(TimeSpan? offset, IUser executor, CancellationToken ct)
+    private Task<Result> SendTimestampAsync(TimeSpan? offset, IUser executor, CancellationToken ct = default)
     {
         var timestamp = DateTimeOffset.UtcNow.Add(offset ?? TimeSpan.Zero).ToUnixTimeSeconds();
 
@@ -249,7 +249,7 @@ public sealed class ToolsCommandGroup : CommandGroup
         return await AnswerEightBallAsync(bot, CancellationToken);
     }
 
-    private Task<Result> AnswerEightBallAsync(IUser bot, CancellationToken ct)
+    private Task<Result> AnswerEightBallAsync(IUser bot, CancellationToken ct = default)
     {
         var typeNumber = Random.Shared.Next(0, 4);
         var embedColor = typeNumber switch

--- a/TeamOctolings.Octobot/Responders/GuildLoadedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/GuildLoadedResponder.cs
@@ -94,7 +94,7 @@ public sealed class GuildLoadedResponder : IResponder<IGuildCreate>
             GuildSettings.PrivateFeedbackChannel.Get(cfg), embedResult: embed, ct: ct);
     }
 
-    private async Task<Result> SendDataLoadFailed(IGuild guild, GuildData data, IUser bot, CancellationToken ct)
+    private async Task<Result> SendDataLoadFailed(IGuild guild, GuildData data, IUser bot, CancellationToken ct = default)
     {
         var channelResult = await _utility.GetEmergencyFeedbackChannel(guild, data, ct);
         if (!channelResult.IsDefined(out var channel))

--- a/TeamOctolings.Octobot/Responders/GuildMemberJoinedResponder.cs
+++ b/TeamOctolings.Octobot/Responders/GuildMemberJoinedResponder.cs
@@ -81,7 +81,7 @@ public sealed class GuildMemberJoinedResponder : IResponder<IGuildMemberAdd>
     }
 
     private async Task<Result> TryReturnRolesAsync(
-        JsonNode cfg, MemberData memberData, Snowflake guildId, Snowflake userId, CancellationToken ct)
+        JsonNode cfg, MemberData memberData, Snowflake guildId, Snowflake userId, CancellationToken ct = default)
     {
         if (!GuildSettings.ReturnRolesOnRejoin.Get(cfg))
         {

--- a/TeamOctolings.Octobot/Services/GuildDataService.cs
+++ b/TeamOctolings.Octobot/Services/GuildDataService.cs
@@ -44,7 +44,7 @@ public sealed class GuildDataService : BackgroundService
         return Task.WhenAll(tasks);
     }
 
-    private static async Task SerializeObjectSafelyAsync<T>(T obj, string path, CancellationToken ct)
+    private static async Task SerializeObjectSafelyAsync<T>(T obj, string path, CancellationToken ct = default)
     {
         var tempFilePath = path + ".tmp";
         await using (var tempFileStream = File.Create(tempFilePath))

--- a/TeamOctolings.Octobot/Services/GuildDataService.cs
+++ b/TeamOctolings.Octobot/Services/GuildDataService.cs
@@ -27,7 +27,7 @@ public sealed class GuildDataService : BackgroundService
         return SaveAsync(ct);
     }
 
-    private Task SaveAsync(CancellationToken ct)
+    private Task SaveAsync(CancellationToken ct = default)
     {
         var tasks = new List<Task>();
         var datas = _datas.Values.ToArray();

--- a/TeamOctolings.Octobot/Services/Update/MemberUpdateService.cs
+++ b/TeamOctolings.Octobot/Services/Update/MemberUpdateService.cs
@@ -62,7 +62,7 @@ public sealed partial class MemberUpdateService : BackgroundService
         }
     }
 
-    private async Task<Result> TickMemberDatasAsync(Snowflake guildId, CancellationToken ct)
+    private async Task<Result> TickMemberDatasAsync(Snowflake guildId, CancellationToken ct = default)
     {
         var guildData = await _guildData.GetData(guildId, ct);
         var defaultRole = GuildSettings.DefaultRole.Get(guildData.Settings);
@@ -79,7 +79,7 @@ public sealed partial class MemberUpdateService : BackgroundService
 
     private async Task<Result> TickMemberDataAsync(Snowflake guildId, GuildData guildData, Snowflake defaultRole,
         MemberData data,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
         var failedResults = new List<Result>();
         var id = data.Id.ToSnowflake();
@@ -144,7 +144,7 @@ public sealed partial class MemberUpdateService : BackgroundService
     }
 
     private async Task<Result> TryAutoUnbanAsync(
-        Snowflake guildId, Snowflake id, MemberData data, CancellationToken ct)
+        Snowflake guildId, Snowflake id, MemberData data, CancellationToken ct = default)
     {
         if (data.BannedUntil is null || DateTimeOffset.UtcNow <= data.BannedUntil)
         {
@@ -169,7 +169,7 @@ public sealed partial class MemberUpdateService : BackgroundService
     }
 
     private async Task<Result> TryAutoUnmuteAsync(
-        Snowflake guildId, Snowflake id, MemberData data, CancellationToken ct)
+        Snowflake guildId, Snowflake id, MemberData data, CancellationToken ct = default)
     {
         if (data.MutedUntil is null || DateTimeOffset.UtcNow <= data.MutedUntil)
         {
@@ -188,7 +188,7 @@ public sealed partial class MemberUpdateService : BackgroundService
     }
 
     private async Task<Result> FilterNicknameAsync(Snowflake guildId, IUser user, IGuildMember member,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
         var currentNickname = member.Nickname.IsDefined(out var nickname)
             ? nickname
@@ -226,7 +226,7 @@ public sealed partial class MemberUpdateService : BackgroundService
     private static partial Regex IllegalChars();
 
     private async Task<Result> TickReminderAsync(Reminder reminder, IUser user, MemberData data, Snowflake guildId,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
         if (DateTimeOffset.UtcNow < reminder.At)
         {

--- a/TeamOctolings.Octobot/Services/Update/ScheduledEventUpdateService.cs
+++ b/TeamOctolings.Octobot/Services/Update/ScheduledEventUpdateService.cs
@@ -46,7 +46,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         }
     }
 
-    private async Task<Result> TickScheduledEventsAsync(Snowflake guildId, CancellationToken ct)
+    private async Task<Result> TickScheduledEventsAsync(Snowflake guildId, CancellationToken ct = default)
     {
         var failedResults = new List<Result>();
         var data = await _guildData.GetData(guildId, ct);
@@ -133,7 +133,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
 
     private async Task<Result> TickScheduledEventAsync(
         Snowflake guildId, GuildData data, IGuildScheduledEvent scheduledEvent, ScheduledEventData eventData,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
         if (GuildSettings.AutoStartEvents.Get(data.Settings)
             && DateTimeOffset.UtcNow >= scheduledEvent.ScheduledStartTime
@@ -160,7 +160,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     }
 
     private async Task<Result> AutoStartEventAsync(
-        Snowflake guildId, IGuildScheduledEvent scheduledEvent, CancellationToken ct)
+        Snowflake guildId, IGuildScheduledEvent scheduledEvent, CancellationToken ct = default)
     {
         return (Result)await _eventApi.ModifyGuildScheduledEventAsync(
             guildId, scheduledEvent.ID,
@@ -319,7 +319,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     }
 
     private async Task<Result> SendScheduledEventCompletedMessage(ScheduledEventData eventData, GuildData data,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
         if (GuildSettings.EventNotificationChannel.Get(data.Settings).Empty())
         {
@@ -351,7 +351,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     }
 
     private async Task<Result> SendScheduledEventCancelledMessage(ScheduledEventData eventData, GuildData data,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
         if (GuildSettings.EventNotificationChannel.Get(data.Settings).Empty())
         {
@@ -405,7 +405,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     }
 
     private async Task<Result> SendEarlyEventNotificationAsync(
-        IGuildScheduledEvent scheduledEvent, GuildData data, CancellationToken ct)
+        IGuildScheduledEvent scheduledEvent, GuildData data, CancellationToken ct = default)
     {
         if (GuildSettings.EventNotificationChannel.Get(data.Settings).Empty())
         {

--- a/TeamOctolings.Octobot/Utility.cs
+++ b/TeamOctolings.Octobot/Utility.cs
@@ -125,7 +125,7 @@ public sealed class Utility
         }
     }
 
-    public async Task<Result<Snowflake>> GetEmergencyFeedbackChannel(IGuild guild, GuildData data, CancellationToken ct)
+    public async Task<Result<Snowflake>> GetEmergencyFeedbackChannel(IGuild guild, GuildData data, CancellationToken ct = default)
     {
         var privateFeedback = GuildSettings.PrivateFeedbackChannel.Get(data.Settings);
         if (!privateFeedback.Empty())


### PR DESCRIPTION
This PR makes sure that a cancellation token is never *required* to use an `async` method. This does not affect user experience in any way, only code quality.