### PR TITLE
Remove Special Thanks in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,16 +32,5 @@ When it comes to contributing to the project, the two main things you can do to 
 submitting pull requests. Please refer to the [contributing guidelines](CONTRIBUTING.md) to understand how to help in
 the most effective way possible.
 
-## Special Thanks
-
-![JetBrains Logo (Main) logo](https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.svg)
-
-[JetBrains](https://www.jetbrains.com/), creators of [ReSharper](https://www.jetbrains.com/resharper)
-and [Rider](https://www.jetbrains.com/rider), supports Octobot with one of
-their [Open Source Licenses](https://jb.gg/OpenSourceSupport).
-Rider is the recommended IDE when working with Octobot, and everyone on the Octobot team uses it.
-Additionally, ReSharper command-line tools made by JetBrains are used for status checks on pull requests to ensure code
-quality even when not using ReSharper or Rider.
-
 #
 <sup>Not an official Splatoon™ product. We are in no way affiliated with or endorsed by Nintendo Company, or other rightsholders.</sup>


### PR DESCRIPTION
Since JetBrains can no longer provide open source licenses due to export restrictions, we can no longer say "special thanks" to JetBrains.