### PR TITLE
Don't log stack traces for cancelled operations

### DIFF
--- a/TeamOctolings.Octobot/Extensions/LoggerExtensions.cs
+++ b/TeamOctolings.Octobot/Extensions/LoggerExtensions.cs
@@ -25,7 +25,7 @@ public static class LoggerExtensions
 
         if (result.Error is ExceptionError exe)
         {
-            if (exe.Exception is TaskCanceledException)
+            if (exe.Exception is OperationCanceledException)
             {
                 return;
             }

--- a/TeamOctolings.Octobot/Extensions/ResultExtensions.cs
+++ b/TeamOctolings.Octobot/Extensions/ResultExtensions.cs
@@ -23,7 +23,7 @@ public static class ResultExtensions
 
     private static void LogResultStackTrace(Result result)
     {
-        if (result.IsSuccess)
+        if (result.IsSuccess || result.Error is ExceptionError { Exception: OperationCanceledException })
         {
             return;
         }


### PR DESCRIPTION
This PR fixes an issue where the `LogResultStackTrace` method would log stack traces for results that encountered an error due to a cancelled operation/task. The `LoggerExtensions` class already skipped `TaskCanceledException`s, but didn't skip `OperationCanceledException`s (which is a parent of `TaskCanceledException`).

The patch specifically does not affect *inner* results which are canceled. Skipping logging these could hide the true cause of an error which appears important