### PR TITLE
/about: Replace repo link with website link

### DIFF
--- a/TeamOctolings.Octobot/BuildInfo.cs
+++ b/TeamOctolings.Octobot/BuildInfo.cs
@@ -2,7 +2,9 @@
 
 public static class BuildInfo
 {
-    public const string RepositoryUrl = "https://github.com/TeamOctolings/Octobot";
+    public const string WebsiteUrl = "https://teamoctolings.github.io/Octobot";
+
+    private const string RepositoryUrl = "https://github.com/TeamOctolings/Octobot";
 
     public const string IssuesUrl = $"{RepositoryUrl}/issues";
 

--- a/TeamOctolings.Octobot/Commands/AboutCommandGroup.cs
+++ b/TeamOctolings.Octobot/Commands/AboutCommandGroup.cs
@@ -106,9 +106,9 @@ public sealed class AboutCommandGroup : CommandGroup
 
         var repositoryButton = new ButtonComponent(
             ButtonComponentStyle.Link,
-            Messages.ButtonOpenRepository,
+            Messages.ButtonOpenWebsite,
             new PartialEmoji(Name: "\ud83c\udf10"), // 'GLOBE WITH MERIDIANS' (U+1F310)
-            URL: BuildInfo.RepositoryUrl
+            URL: BuildInfo.WebsiteUrl
         );
 
         var wikiButton = new ButtonComponent(

--- a/TeamOctolings.Octobot/Messages.Designer.cs
+++ b/TeamOctolings.Octobot/Messages.Designer.cs
@@ -633,9 +633,9 @@ namespace TeamOctolings.Octobot {
             }
         }
         
-        internal static string ButtonOpenRepository {
+        internal static string ButtonOpenWebsite {
             get {
-                return ResourceManager.GetString("ButtonOpenRepository", resourceCulture);
+                return ResourceManager.GetString("ButtonOpenWebsite", resourceCulture);
             }
         }
         

--- a/TeamOctolings.Octobot/Messages.resx
+++ b/TeamOctolings.Octobot/Messages.resx
@@ -399,8 +399,8 @@
   <data name="AboutTitleDevelopers" xml:space="preserve">
     <value>Developers:</value>
   </data>
-  <data name="ButtonOpenRepository" xml:space="preserve">
-    <value>Octobot's source code</value>
+  <data name="ButtonOpenWebsite" xml:space="preserve">
+      <value>Open Website</value>
   </data>
   <data name="AboutBot" xml:space="preserve">
       <value>About {0}</value>

--- a/TeamOctolings.Octobot/Messages.ru.resx
+++ b/TeamOctolings.Octobot/Messages.ru.resx
@@ -399,8 +399,8 @@
   <data name="AboutTitleDevelopers" xml:space="preserve">
     <value>Разработчики:</value>
   </data>
-  <data name="ButtonOpenRepository" xml:space="preserve">
-    <value>Исходный код Octobot</value>
+  <data name="ButtonOpenWebsite" xml:space="preserve">
+      <value>Открыть веб-сайт</value>
   </data>
   <data name="AboutBot" xml:space="preserve">
       <value>О боте {0}</value>


### PR DESCRIPTION
A some sort of UX change. Repository link will be still accessible from the website.