### PR TITLE
Update dependencies

### DIFF
--- a/TeamOctolings.Octobot/TeamOctolings.Octobot.csproj
+++ b/TeamOctolings.Octobot/TeamOctolings.Octobot.csproj
@@ -24,14 +24,14 @@
         <PackageReference Include="DiffPlex" Version="1.7.2" />
         <PackageReference Include="GitInfo" Version="3.3.5" />
         <PackageReference Include="Humanizer.Core.ru" Version="2.14.1" />
-        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2024.2.0"/>
         <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-        <PackageReference Include="Remora.Commands" Version="10.0.5" />
+        <PackageReference Include="Remora.Commands" Version="10.0.6"/>
         <PackageReference Include="Remora.Discord.Caching" Version="39.0.0" />
-        <PackageReference Include="Remora.Discord.Extensions" Version="5.3.5" />
+        <PackageReference Include="Remora.Discord.Extensions" Version="5.3.6"/>
         <PackageReference Include="Remora.Discord.Hosting" Version="6.0.10" />
-        <PackageReference Include="Remora.Discord.Interactivity" Version="4.5.4" />
+        <PackageReference Include="Remora.Discord.Interactivity" Version="5.0.0"/>
         <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
this is supposed to be Dependabot's job, but ig something happened to it

Bumps `JetBrains.Annotations` from `2023.3.0` to `2024.2.0`
<details><summary>Changelog</summary>
• Added DefaultEqualityUsageAttribute for equality members usage analysis.
• MustDisposeResourceAttribute is now allowed on struct types.
• Added ability to specify the description for UsedImplicitlyAttribute (new 'Reason' property).
• Added copyright information to nuspec.
</details>

Bumps `Remora.Commands` from `10.0.5` to `10.0.6`
<details><summary>Changelog</summary>
Upgrade Remora.Sdk.
           Upgrade nuget packages.
</details>

Bumps `Remora.Discord.Extensions` from `5.3.5` to `5.3.6`
Bumps `Remora.Discord.Interactivity` from `4.5.4` to `5.0.0`
<details><summary>Changelog</summary>
Update dependencies.
           BREAKING: Rework deletion logic for data leases to prevent deadlocks.
</details>

The breaking change in Remora should not affect us.