### PR TITLE
Upload solution instead of updating container on production

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -35,10 +35,20 @@ jobs:
   update-production:
     name: Update Octobot on production
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     environment: production
-    needs: upload-image
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Publish solution
+        run: dotnet publish $PUBLISH_FLAGS
+        env:
+          PUBLISH_FLAGS: ${{vars.PUBLISH_FLAGS}}
+
       - name: Copy SSH key
         run: |
           install -m 600 -D /dev/null ~/.ssh/id_ed25519
@@ -46,7 +56,7 @@ jobs:
         shell: bash
         env:
           SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
-          
+
       - name: Generate SSH known hosts file
         run: |
           ssh-keyscan -H -p $SSH_PORT $SSH_HOST > ~/.ssh/known_hosts
@@ -54,7 +64,7 @@ jobs:
         env:
           SSH_HOST: ${{secrets.SSH_HOST}}
           SSH_PORT: ${{secrets.SSH_PORT}}
-          
+
       - name: Stop currently running instance
         run: |
           ssh -p $SSH_PORT $SSH_USER@$SSH_HOST $STOP_COMMAND
@@ -65,16 +75,16 @@ jobs:
           SSH_HOST: ${{secrets.SSH_HOST}}
           STOP_COMMAND: ${{vars.STOP_COMMAND}}
 
-      - name: Update Docker image
+      - name: Upload published solution
         run: |
-          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST docker pull ghcr.io/$NAMESPACE/$IMAGE_NAME:latest
+          scp -r -p $SSH_PORT $UPLOAD_FROM $SSH_USER@$SSH_HOST:$UPLOAD_TO
         shell: bash
         env:
           SSH_PORT: ${{secrets.SSH_PORT}}
           SSH_USER: ${{secrets.SSH_USER}}
           SSH_HOST: ${{secrets.SSH_HOST}}
-          NAMESPACE: ${{vars.NAMESPACE}}
-          IMAGE_NAME: ${{vars.IMAGE_NAME}}
+          UPLOAD_FROM: ${{vars.UPLOAD_FROM}}
+          UPLOAD_TO: ${{vars.UPLOAD_TO}}
 
       - name: Start new instance
         run: |


### PR DESCRIPTION
We no longer use the Wireguard container to run Octobot on the production server.