### PR TITLE
Downgrade GitInfo from 3.5.0 to 3.3.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,6 @@ updates:
           - "Remora.Discord.*"
     # For all packages, ignore all patch updates
     ignore:
+      - dependency-name: "GitInfo"
       - dependency-name: "*"
         update-types: [ "version-update:semver-patch" ]

--- a/TeamOctolings.Octobot/TeamOctolings.Octobot.csproj
+++ b/TeamOctolings.Octobot/TeamOctolings.Octobot.csproj
@@ -22,7 +22,7 @@
 
     <ItemGroup>
         <PackageReference Include="DiffPlex" Version="1.7.2" />
-        <PackageReference Include="GitInfo" Version="3.5.0" />
+        <PackageReference Include="GitInfo" Version="3.3.5" />
         <PackageReference Include="Humanizer.Core.ru" Version="2.14.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0"/>
         <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />


### PR DESCRIPTION
This pull request downgrades GitInfo from 3.5.0 to 3.3.5 due to a decision from the maintainers to lock features behind a paywall. 
![image](https://github.com/user-attachments/assets/f90eba84-1a1e-43eb-950e-e233a02feb9a)
