### PR TITLE
Handle temporary files being present when loading guild data

### DIFF
--- a/TeamOctolings.Octobot/Extensions/GuildScheduledEventExtensions.cs
+++ b/TeamOctolings.Octobot/Extensions/GuildScheduledEventExtensions.cs
@@ -10,7 +10,7 @@ public static class GuildScheduledEventExtensions
         out string? location)
     {
         endTime = default;
-        location = default;
+        location = null;
         if (!scheduledEvent.EntityMetadata.AsOptional().IsDefined(out var metadata))
         {
             return new ArgumentNullError(nameof(scheduledEvent.EntityMetadata));


### PR DESCRIPTION
This PR fixes catastrophic guild data loading errors that appear when there are lingering temporary files. In normal operation, temporary files are deleted as soon as they are copied to the main file. It is also expected that temporary files are valid JSON files.

However, due to a yesterday's DoS attack, something:tm: happened and a bunch of empty temporary files got written to disk. When Octobot recovered from the attack, it was unable to load any guild data because of the temporary files.

This PR addresses this issue by changing the data loading logic:
1) Check if there's a temporary file. If it exists, try loading it.
2) If it is successfully loaded, move the temp file to the main file and resume operation as normal
3) If it could not be loaded, try loading the main file
4) If it is successfully loaded, delete the temporary file and resume operation as normal
5) If it is not, throw an error (like before)

This PR was tested on production data and managed to load every guild without errors.